### PR TITLE
support prop: allowReset

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+- Add allowClear support.
+
 ## 2.3.0
 
 - Add keyboard support.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ React.render(<Rate />, container);
           <td>support half star</td>
         </tr>
         <tr>
+          <td>allowClear</td>
+          <td>bool</td>
+          <td>true</td>
+          <td>reset when click again</td>
+        </tr>
+        <tr>
           <td>style</td>
           <td>object</td>
           <td>{}</td>

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -15,6 +15,7 @@ ReactDOM.render(
       onChange={onChange}
       style={{ fontSize: 40 }}
       allowHalf
+      allowClear={false}
     />
     <br />
     <Rate
@@ -30,6 +31,13 @@ ReactDOM.render(
       onChange={onChange}
       style={{ fontSize: 50, marginTop: 24 }}
       allowHalf
+      character={<i className="anticon anticon-star" />}
+    />
+    <br />
+    <Rate
+      defaultValue={2}
+      onChange={onChange}
+      style={{ fontSize: 50, marginTop: 24 }}
       character={<i className="anticon anticon-star" />}
     />
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rc-rate",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "React Star Rate Component",
   "keywords": [
     "react",

--- a/src/Rate.jsx
+++ b/src/Rate.jsx
@@ -55,7 +55,7 @@ export default class Rate extends React.Component {
     this.state = {
       value,
       focused: false,
-      CleanedValue: null,
+      cleanedValue: null,
     };
   }
 
@@ -79,11 +79,11 @@ export default class Rate extends React.Component {
 
   onHover = (event, index) => {
     const hoverValue = this.getStarValue(index, event.pageX);
-    const { CleanedValue } = this.state;
-    if (hoverValue !== CleanedValue) {
+    const { cleanedValue } = this.state;
+    if (hoverValue !== cleanedValue) {
       this.setState({
         hoverValue,
-        CleanedValue: null,
+        cleanedValue: null,
       });
     }
     this.props.onHoverChange(hoverValue);
@@ -92,7 +92,7 @@ export default class Rate extends React.Component {
   onMouseLeave = () => {
     this.setState({
       hoverValue: undefined,
-      CleanedValue: null,
+      cleanedValue: null,
     });
     this.props.onHoverChange(undefined);
   }
@@ -106,7 +106,7 @@ export default class Rate extends React.Component {
     this.onMouseLeave(true);
     this.changeValue(isReset ? 0 : value);
     this.setState({
-      CleanedValue: isReset ? value : null,
+      cleanedValue: isReset ? value : null,
     });
   }
 

--- a/src/Rate.jsx
+++ b/src/Rate.jsx
@@ -16,6 +16,7 @@ export default class Rate extends React.Component {
     defaultValue: PropTypes.number,
     count: PropTypes.number,
     allowHalf: PropTypes.bool,
+    allowClear: PropTypes.bool,
     style: PropTypes.object,
     prefixCls: PropTypes.string,
     onChange: PropTypes.func,
@@ -33,6 +34,7 @@ export default class Rate extends React.Component {
     defaultValue: 0,
     count: 5,
     allowHalf: false,
+    allowClear: true,
     style: {},
     prefixCls: 'rc-rate',
     onChange: noop,
@@ -53,6 +55,7 @@ export default class Rate extends React.Component {
     this.state = {
       value,
       focused: false,
+      CleanedValue: null,
     };
   }
 
@@ -76,23 +79,35 @@ export default class Rate extends React.Component {
 
   onHover = (event, index) => {
     const hoverValue = this.getStarValue(index, event.pageX);
-    this.setState({
-      hoverValue,
-    });
+    const { CleanedValue } = this.state;
+    if (hoverValue !== CleanedValue) {
+      this.setState({
+        hoverValue,
+        CleanedValue: null,
+      });
+    }
     this.props.onHoverChange(hoverValue);
   }
 
   onMouseLeave = () => {
     this.setState({
       hoverValue: undefined,
+      CleanedValue: null,
     });
     this.props.onHoverChange(undefined);
   }
 
   onClick = (event, index) => {
     const value = this.getStarValue(index, event.pageX);
-    this.onMouseLeave();
-    this.changeValue(value);
+    let isReset = false;
+    if (this.props.allowClear) {
+      isReset = value === this.state.value;
+    }
+    this.onMouseLeave(true);
+    this.changeValue(isReset ? 0 : value);
+    this.setState({
+      CleanedValue: isReset ? value : null,
+    });
   }
 
   onFocus = () => {
@@ -148,9 +163,10 @@ export default class Rate extends React.Component {
   getStarValue(index, x) {
     let value = index + 1;
     if (this.props.allowHalf) {
-      const leftEdge = getOffsetLeft(this.getStarDOM(0));
-      const width = getOffsetLeft(this.getStarDOM(1)) - leftEdge;
-      if ((x - leftEdge - width * index) < width / 2) {
+      const starEle = this.getStarDOM(index);
+      const leftDis = getOffsetLeft(starEle);
+      const width = starEle.clientWidth;
+      if ((x - leftDis) < width / 2) {
         value -= 0.5;
       }
     }

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -76,6 +76,26 @@ describe('rate', () => {
     });
   });
 
+  describe('allowClear', () => {
+    it('allowClear is false', () => {
+      const handleChange = jest.fn();
+      const wrapper = mount(
+        <Rate count={5} value={1} allowClear={false} onChange={handleChange} />
+      );
+      wrapper.find('li').at(3).simulate('click');
+      wrapper.find('li').at(3).simulate('click');
+      expect(handleChange).toBeCalledWith(4);
+    });
+    it('allowClear is true', () => {
+      const handleChange = jest.fn();
+      const wrapper = mount(
+        <Rate count={5} value={4} onChange={handleChange} />
+      );
+      wrapper.find('li').at(3).simulate('click');
+      expect(handleChange).toBeCalledWith(0);
+    });
+  });
+
   describe('focus & blur', () => {
     let container;
     beforeEach(() => {

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -48,6 +48,16 @@ describe('rate', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('click works', () => {
+      const wrapper = mount(
+        <Rate count={5} value={4.5} allowHalf />
+      );
+      wrapper.find('li').at(2).simulate('click');
+      expect(
+        wrapper.find('li').at(4).hasClass('rc-rate-star-full')
+      ).toBe(false);
+    });
+
     it('support focus and blur', () => {
       const wrapper = mount(
         <Rate count={3} value={1.5} allowHalf />
@@ -93,6 +103,27 @@ describe('rate', () => {
       );
       wrapper.find('li').at(3).simulate('click');
       expect(handleChange).toBeCalledWith(0);
+    });
+    it('cleaned star disable hover', () => {
+      const wrapper = mount(
+        <Rate count={5} defaultValue={4} />
+      );
+      wrapper.find('li').at(3).simulate('click');
+      wrapper.find('li').at(3).simulate('mouseMove');
+      expect(
+        wrapper.find('li').at(3).hasClass('rc-rate-star-full')
+      ).toBe(false);
+    });
+    it('cleaned star reset', () => {
+      const wrapper = mount(
+        <Rate count={5} defaultValue={4} />
+      );
+      wrapper.find('li').at(3).simulate('click');
+      wrapper.find('ul').simulate('mouseLeave');
+      wrapper.find('li').at(3).simulate('mouseMove');
+      expect(
+        wrapper.find('li').at(3).hasClass('rc-rate-star-full')
+      ).toBe(true);
     });
   });
 


### PR DESCRIPTION
![startreset](https://user-images.githubusercontent.com/1061968/33917588-26d640d2-dfea-11e7-9cc9-3603a15bd8ac.gif)

PS：做的时候发现有一个问题，因为选中和将要被选中是一样的效果，所以如果用户点击触发 reset 的时候鼠标挪动了一下，会导致 reset 的行为感知不出来，如下图：

![startreset2](https://user-images.githubusercontent.com/1061968/33917718-d6270378-dfea-11e7-8aab-7daa38365d4a.gif)
