### PR TITLE
feat: expand character

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ ReactDOM.render(
         </tr>
         <tr>
           <td>character</td>
-          <td>ReactNode | index => ReactNode</td>
+          <td>ReactNode | ({index}) => ReactNode</td>
           <td>★</td>
           <td>The each character of rate</td>
         </tr>

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ ReactDOM.render(
         </tr>
         <tr>
           <td>character</td>
-          <td>ReactNode</td>
+          <td>ReactNode | index => ReactNode</td>
           <td>★</td>
           <td>The each character of rate</td>
         </tr>

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -30,8 +30,7 @@ export default () => (
       defaultValue={1}
       onChange={onChange}
       style={{ fontSize: 50, marginTop: 24 }}
-      character="1"
-      iconRender={index => {
+      character={index => {
         return index + 1;
       }}
     />

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -30,7 +30,7 @@ export default () => (
       defaultValue={1}
       onChange={onChange}
       style={{ fontSize: 50, marginTop: 24 }}
-      character={index => {
+      character={({ index }) => {
         return index + 1;
       }}
     />

--- a/examples/simple.tsx
+++ b/examples/simple.tsx
@@ -27,6 +27,16 @@ export default () => (
     />
     <br />
     <Rate
+      defaultValue={1}
+      onChange={onChange}
+      style={{ fontSize: 50, marginTop: 24 }}
+      character="1"
+      iconRender={index => {
+        return index + 1;
+      }}
+    />
+    <br />
+    <Rate
       defaultValue={2.5}
       onChange={onChange}
       style={{ fontSize: 50, marginTop: 24 }}

--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -19,8 +19,7 @@ export interface RateProps {
   onChange?: (value: number) => void;
   onHoverChange?: (value: number) => void;
   className?: string;
-  character?: React.ReactNode;
-  iconRender?: (index: number) => React.ReactNode;
+  character?: (index: number) => React.ReactNode | React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   tabIndex?: number;
   onFocus?: () => void;
@@ -251,7 +250,6 @@ class Rate extends React.Component<RateProps, RateState> {
       disabled,
       className,
       character,
-      iconRender,
       characterRender,
       tabIndex,
       direction,
@@ -273,7 +271,6 @@ class Rate extends React.Component<RateProps, RateState> {
           onHover={this.onHover}
           key={index}
           character={character}
-          iconRender={iconRender}
           characterRender={characterRender}
           focused={focused}
         />,

--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -20,6 +20,7 @@ export interface RateProps {
   onHoverChange?: (value: number) => void;
   className?: string;
   character?: React.ReactNode;
+  iconRender?: (index: number) => React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   tabIndex?: number;
   onFocus?: () => void;
@@ -156,7 +157,7 @@ class Rate extends React.Component<RateProps, RateState> {
       }
       this.changeValue(value);
       event.preventDefault();
-    } else if (keyCode === KeyCode.RIGHT && value > 0 && reverse){
+    } else if (keyCode === KeyCode.RIGHT && value > 0 && reverse) {
       if (allowHalf) {
         value -= 0.5;
       } else {
@@ -164,7 +165,7 @@ class Rate extends React.Component<RateProps, RateState> {
       }
       this.changeValue(value);
       event.preventDefault();
-    } else if (keyCode === KeyCode.LEFT && value < count && reverse){
+    } else if (keyCode === KeyCode.LEFT && value < count && reverse) {
       if (allowHalf) {
         value += 0.5;
       } else {
@@ -250,6 +251,7 @@ class Rate extends React.Component<RateProps, RateState> {
       disabled,
       className,
       character,
+      iconRender,
       characterRender,
       tabIndex,
       direction,
@@ -271,6 +273,7 @@ class Rate extends React.Component<RateProps, RateState> {
           onHover={this.onHover}
           key={index}
           character={character}
+          iconRender={iconRender}
           characterRender={characterRender}
           focused={focused}
         />,

--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -19,7 +19,7 @@ export interface RateProps {
   onChange?: (value: number) => void;
   onHoverChange?: (value: number) => void;
   className?: string;
-  character?: (index: number) => React.ReactNode | React.ReactNode;
+  character?: ({ index: number }) => React.ReactNode | React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   tabIndex?: number;
   onFocus?: () => void;

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -58,7 +58,7 @@ export default class Star extends React.Component<StarProps> {
   render() {
     const { onHover, onClick, onKeyDown } = this;
     const { disabled, prefixCls, character, characterRender, index, count, value } = this.props;
-    const iconNode = typeof character === 'function' ? character(index) : character;
+    const characterNode = typeof character === 'function' ? character(index) : character;
     let start: React.ReactNode = (
       <li className={this.getClassName()}>
         <div
@@ -71,8 +71,8 @@ export default class Star extends React.Component<StarProps> {
           aria-setsize={count}
           tabIndex={0}
         >
-          <div className={`${prefixCls}-first`}>{iconNode}</div>
-          <div className={`${prefixCls}-second`}>{iconNode}</div>
+          <div className={`${prefixCls}-first`}>{characterNode}</div>
+          <div className={`${prefixCls}-second`}>{characterNode}</div>
         </div>
       </li>
     );

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -11,7 +11,7 @@ export interface StarProps {
     e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
     index: number,
   ) => void;
-  character?: (index: number) => React.ReactNode | React.ReactNode;
+  character?: ({ index: number }) => React.ReactNode | React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   focused?: boolean;
   count?: number;

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -58,7 +58,7 @@ export default class Star extends React.Component<StarProps> {
   render() {
     const { onHover, onClick, onKeyDown } = this;
     const { disabled, prefixCls, character, characterRender, index, count, value } = this.props;
-    const characterNode = typeof character === 'function' ? character(index) : character;
+    const characterNode = typeof character === 'function' ? character({ index }) : character;
     let start: React.ReactNode = (
       <li className={this.getClassName()}>
         <div

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -12,6 +12,7 @@ export interface StarProps {
     index: number,
   ) => void;
   character?: React.ReactNode;
+  iconRender?: (index: number) => React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   focused?: boolean;
   count?: number;
@@ -57,7 +58,17 @@ export default class Star extends React.Component<StarProps> {
 
   render() {
     const { onHover, onClick, onKeyDown } = this;
-    const { disabled, prefixCls, character, characterRender, index, count, value } = this.props;
+    const {
+      disabled,
+      prefixCls,
+      character,
+      iconRender,
+      characterRender,
+      index,
+      count,
+      value,
+    } = this.props;
+    const iconNode = iconRender ? iconRender(index) : character;
     let start: React.ReactNode = (
       <li className={this.getClassName()}>
         <div
@@ -70,8 +81,8 @@ export default class Star extends React.Component<StarProps> {
           aria-setsize={count}
           tabIndex={0}
         >
-          <div className={`${prefixCls}-first`}>{character}</div>
-          <div className={`${prefixCls}-second`}>{character}</div>
+          <div className={`${prefixCls}-first`}>{iconNode}</div>
+          <div className={`${prefixCls}-second`}>{iconNode}</div>
         </div>
       </li>
     );

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -11,8 +11,7 @@ export interface StarProps {
     e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,
     index: number,
   ) => void;
-  character?: React.ReactNode;
-  iconRender?: (index: number) => React.ReactNode;
+  character?: (index: number) => React.ReactNode | React.ReactNode;
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   focused?: boolean;
   count?: number;
@@ -58,17 +57,8 @@ export default class Star extends React.Component<StarProps> {
 
   render() {
     const { onHover, onClick, onKeyDown } = this;
-    const {
-      disabled,
-      prefixCls,
-      character,
-      iconRender,
-      characterRender,
-      index,
-      count,
-      value,
-    } = this.props;
-    const iconNode = iconRender ? iconRender(index) : character;
+    const { disabled, prefixCls, character, characterRender, index, count, value } = this.props;
+    const iconNode = typeof character === 'function' ? character(index) : character;
     let start: React.ReactNode = (
       <li className={this.getClassName()}>
         <div

--- a/tests/__snapshots__/simple.spec.js.snap
+++ b/tests/__snapshots__/simple.spec.js.snap
@@ -300,9 +300,9 @@ exports[`rate full render works in RTL 1`] = `
 </ul>
 `;
 
-exports[`rate full render works in RTL 1`] = `
+exports[`rate full render works with character function 1`] = `
 <ul
-  class="rc-rate custom rc-rate-rtl"
+  class="rc-rate"
   role="radiogroup"
   tabindex="0"
 >
@@ -319,12 +319,12 @@ exports[`rate full render works in RTL 1`] = `
       <div
         class="rc-rate-star-first"
       >
-        ★
+        1
       </div>
       <div
         class="rc-rate-star-second"
       >
-        ★
+        1
       </div>
     </div>
   </li>
@@ -341,12 +341,12 @@ exports[`rate full render works in RTL 1`] = `
       <div
         class="rc-rate-star-first"
       >
-        ★
+        2
       </div>
       <div
         class="rc-rate-star-second"
       >
-        ★
+        2
       </div>
     </div>
   </li>
@@ -363,12 +363,87 @@ exports[`rate full render works in RTL 1`] = `
       <div
         class="rc-rate-star-first"
       >
-        ★
+        3
       </div>
       <div
         class="rc-rate-star-second"
       >
-        ★
+        3
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
+exports[`rate full render works with character node 1`] = `
+<ul
+  class="rc-rate"
+  role="radiogroup"
+  tabindex="0"
+>
+  <li
+    class="rc-rate-star rc-rate-star-full"
+  >
+    <div
+      aria-checked="true"
+      aria-posinset="1"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        1
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        1
+      </div>
+    </div>
+  </li>
+  <li
+    class="rc-rate-star rc-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="2"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        1
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        1
+      </div>
+    </div>
+  </li>
+  <li
+    class="rc-rate-star rc-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="3"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        1
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        1
       </div>
     </div>
   </li>

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -25,7 +25,7 @@ describe('rate', () => {
         <Rate
           count={3}
           value={1}
-          character={index => {
+          character={({ index }) => {
             return index + 1;
           }}
         />,

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -15,6 +15,24 @@ describe('rate', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('render works with character node', () => {
+      const wrapper = render(<Rate count={3} value={1} character="1" />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('render works with character function', () => {
+      const wrapper = render(
+        <Rate
+          count={3}
+          value={1}
+          character={index => {
+            return index + 1;
+          }}
+        />,
+      );
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('click works', () => {
       const handleChange = jest.fn();
       const wrapper = mount(<Rate count={3} value={1} onChange={handleChange} />);
@@ -223,7 +241,9 @@ describe('rate', () => {
 
     it('support keyboard in RTL', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1.5} allowHalf direction="rtl" onChange={handleChange} />);
+      const wrapper = mount(
+        <Rate count={3} value={1.5} allowHalf direction="rtl" onChange={handleChange} />,
+      );
       wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
       expect(handleChange).toBeCalledWith(2);
       handleChange.mockReset();
@@ -245,7 +265,9 @@ describe('rate', () => {
 
     it('hover Rate of allowHalf and rtl', () => {
       const onHoverChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1} allowHalf direction="rtl" onHoverChange={onHoverChange} />);
+      const wrapper = mount(
+        <Rate count={3} value={1} allowHalf direction="rtl" onHoverChange={onHoverChange} />,
+      );
       wrapper
         .find('li > div')
         .at(1)


### PR DESCRIPTION
### picture

![2020-06-10 15 00 37](https://user-images.githubusercontent.com/29775873/84237218-8b770d00-ab2b-11ea-8175-5cede6ce727b.gif)

### Link issue

https://github.com/ant-design/ant-design/issues/24857

### background

<details>
<summary>past</summary>

`character={index => ReactNode}`
这种没弄出来，character 即是 ReactNode 又是一个 function。

所以新加了一个 iconRender。

看了一下 https://material-ui.com/api/rating/#props
他们用的 icon 和 IconContainerComponent， 分开处理。

揉一起用一个 character 真是搞不定啊。。。。😔😔😔

</details>


----

扩展 character 以 支持 (index) => ReactNode