### PR TITLE
fix: improve defaultvalue more than half

### DIFF
--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -41,7 +41,7 @@ export default class Star extends React.Component<StarProps> {
     let className = prefixCls;
     if (value === 0 && index === 0 && focused) {
       className += ` ${prefixCls}-focused`;
-    } else if (allowHalf && value + 0.5 === starValue) {
+    } else if (allowHalf && value + 0.5 >= starValue && value < starValue) {
       className += ` ${prefixCls}-half ${prefixCls}-active`;
       if (focused) {
         className += ` ${prefixCls}-focused`;

--- a/tests/__snapshots__/simple.spec.js.snap
+++ b/tests/__snapshots__/simple.spec.js.snap
@@ -150,6 +150,81 @@ exports[`rate allowHalf render works in RTL 1`] = `
 </ul>
 `;
 
+exports[`rate allowHalf render works more than half  1`] = `
+<ul
+  class="rc-rate custom"
+  role="radiogroup"
+  tabindex="0"
+>
+  <li
+    class="rc-rate-star rc-rate-star-full"
+  >
+    <div
+      aria-checked="true"
+      aria-posinset="1"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        ★
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        ★
+      </div>
+    </div>
+  </li>
+  <li
+    class="rc-rate-star rc-rate-star-half rc-rate-star-active"
+  >
+    <div
+      aria-checked="true"
+      aria-posinset="2"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        ★
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        ★
+      </div>
+    </div>
+  </li>
+  <li
+    class="rc-rate-star rc-rate-star-zero"
+  >
+    <div
+      aria-checked="false"
+      aria-posinset="3"
+      aria-setsize="3"
+      role="radio"
+      tabindex="0"
+    >
+      <div
+        class="rc-rate-star-first"
+      >
+        ★
+      </div>
+      <div
+        class="rc-rate-star-second"
+      >
+        ★
+      </div>
+    </div>
+  </li>
+</ul>
+`;
+
 exports[`rate full render works 1`] = `
 <ul
   class="rc-rate custom"

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -170,6 +170,11 @@ describe('rate', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
+    it('render works more than half ', () => {
+      const wrapper = render(<Rate count={3} value={1.6} allowHalf className="custom" />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('render works in RTL', () => {
       const wrapper = render(
         <Rate count={3} value={1.5} allowHalf direction="rtl" className="custom" />,


### PR DESCRIPTION
### Link issue
close https://github.com/react-component/rate/issues/13

### changelog
改进类似于 `defaultvalue=1.6` 的初始化