### PR TITLE
feat: highlight selected only

### DIFF
--- a/docs/examples/simple.tsx
+++ b/docs/examples/simple.tsx
@@ -28,6 +28,7 @@ export default () => (
     <br />
     <Rate
       defaultValue={1}
+      highlightSelectedOnly
       onChange={onChange}
       style={{ fontSize: 50, marginTop: 24 }}
       character={({ index }) => {

--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -8,7 +8,7 @@ import type { StarProps } from './Star';
 
 function noop() {}
 
-export interface RateProps extends Pick<StarProps, "count" | "character" | "characterRender" | "allowHalf" | "disabled"> {
+export interface RateProps extends Pick<StarProps, "count" | "character" | "characterRender" | "allowHalf" | "disabled" | "highlightSelectedOnly"> {
   value?: number;
   defaultValue?: number;
   allowClear?: boolean;
@@ -45,6 +45,7 @@ class Rate extends React.Component<RateProps, RateState> {
     onHoverChange: noop,
     tabIndex: 0,
     direction: 'ltr',
+    highlightSelectedOnly: false,
   };
 
   stars: Record<string, Star>;
@@ -249,6 +250,7 @@ class Rate extends React.Component<RateProps, RateState> {
       characterRender,
       tabIndex,
       direction,
+      highlightSelectedOnly
     } = this.props;
     const { value, hoverValue, focused } = this.state;
     const stars = [];
@@ -269,6 +271,7 @@ class Rate extends React.Component<RateProps, RateState> {
           character={character}
           characterRender={characterRender}
           focused={focused}
+          highlightSelectedOnly={highlightSelectedOnly}
         />,
       );
     }

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -15,6 +15,7 @@ export interface StarProps {
   characterRender?: (origin: React.ReactElement, props: StarProps) => React.ReactNode;
   focused?: boolean;
   count?: number;
+  highlightSelectedOnly?: boolean;
 }
 
 export default class Star extends React.Component<StarProps> {
@@ -36,7 +37,7 @@ export default class Star extends React.Component<StarProps> {
   };
 
   getClassName() {
-    const { prefixCls, index, value, allowHalf, focused } = this.props;
+    const { prefixCls, index, value, allowHalf, focused, highlightSelectedOnly } = this.props;
     const starValue = index + 1;
     let className = prefixCls;
     if (value === 0 && index === 0 && focused) {
@@ -46,7 +47,7 @@ export default class Star extends React.Component<StarProps> {
       if (focused) {
         className += ` ${prefixCls}-focused`;
       }
-    } else {
+    } else if (!highlightSelectedOnly || value === index + 1) {
       className += starValue <= value ? ` ${prefixCls}-full` : ` ${prefixCls}-zero`;
       if (starValue === value && focused) {
         className += ` ${prefixCls}-focused`;


### PR DESCRIPTION
Added `highlightSelectedOnly` prop, to allow only one star to be highlighted at the same time.
@afc163 Can we merge this and release new version after this?

https://user-images.githubusercontent.com/12899161/143721196-0b1718cc-bcaa-402e-ba74-d8de5da08278.mp4

