### PR TITLE
fix: correct role for a11y

### DIFF
--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -238,7 +238,6 @@ function Rate(props: RateProps, ref: React.Ref<RateRef>) {
       onBlur={disabled ? null : onInternalBlur}
       onKeyDown={disabled ? null : onInternalKeyDown}
       ref={rateRef}
-      role="radiogroup"
       {...pickAttrs(restProps, { aria: true, data: true, attr: true })}
     >
       {starNodes}

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -79,10 +79,10 @@ function Star(props: StarProps, ref: React.Ref<HTMLLIElement>) {
   let start: React.ReactNode = (
     <li className={classNames(Array.from(classNameList))} ref={ref}>
       <div
+        role="radio"
         onClick={disabled ? null : onInternalClick}
         onKeyDown={disabled ? null : onInternalKeyDown}
         onMouseMove={disabled ? null : onInternalHover}
-        role="radio"
         aria-checked={value > index ? 'true' : 'false'}
         aria-posinset={index + 1}
         aria-setsize={count}

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -79,10 +79,10 @@ function Star(props: StarProps, ref: React.Ref<HTMLLIElement>) {
   let start: React.ReactNode = (
     <li className={classNames(Array.from(classNameList))} ref={ref}>
       <div
-        role="radio"
         onClick={disabled ? null : onInternalClick}
         onKeyDown={disabled ? null : onInternalKeyDown}
         onMouseMove={disabled ? null : onInternalHover}
+        role="radio"
         aria-checked={value > index ? 'true' : 'false'}
         aria-posinset={index + 1}
         aria-setsize={count}

--- a/tests/__snapshots__/simple.spec.js.snap
+++ b/tests/__snapshots__/simple.spec.js.snap
@@ -3,7 +3,6 @@
 exports[`rate allowHalf render works 1`] = `
 <ul
   class="rc-rate custom"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -78,7 +77,6 @@ exports[`rate allowHalf render works 1`] = `
 exports[`rate allowHalf render works in RTL 1`] = `
 <ul
   class="rc-rate custom rc-rate-rtl"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -153,7 +151,6 @@ exports[`rate allowHalf render works in RTL 1`] = `
 exports[`rate allowHalf render works more than half  1`] = `
 <ul
   class="rc-rate custom"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -228,7 +225,6 @@ exports[`rate allowHalf render works more than half  1`] = `
 exports[`rate full render works 1`] = `
 <ul
   class="rc-rate custom"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -303,7 +299,6 @@ exports[`rate full render works 1`] = `
 exports[`rate full render works in RTL 1`] = `
 <ul
   class="rc-rate custom rc-rate-rtl"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -378,7 +373,6 @@ exports[`rate full render works in RTL 1`] = `
 exports[`rate full render works with character function 1`] = `
 <ul
   class="rc-rate"
-  role="radiogroup"
   tabindex="0"
 >
   <li
@@ -453,7 +447,6 @@ exports[`rate full render works with character function 1`] = `
 exports[`rate full render works with character node 1`] = `
 <ul
   class="rc-rate"
-  role="radiogroup"
   tabindex="0"
 >
   <li


### PR DESCRIPTION
![QQ_1737711246873](https://github.com/user-attachments/assets/a99a2ba5-ea8c-4775-8c10-c0958b7ff358)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式调整**
	- 修改了评分组件的无障碍属性，移除了 `role="radiogroup"` 属性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->