### PR TITLE
Avoid deep imports and migrate tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
 module.exports = {
-  setupFiles: ["./tests/setup.js"],
-  snapshotSerializers: [require.resolve("enzyme-to-json/serializer")],
+  setupFiles: ['./tests/setup.js'],
 };

--- a/package.json
+++ b/package.json
@@ -40,31 +40,28 @@
     "tsc": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "@rc-component/util": "^1.3.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.1.3",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.0",
     "@rc-component/tooltip": "^1.2.1",
+    "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.1",
     "@types/node": "^24.5.2",
-    "@types/react": "^17.0.15",
-    "@types/react-dom": "^17.0.9",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@umijs/fabric": "^3.0.0",
-    "cheerio": "1.0.0-rc.12",
     "cross-env": "^7.0.0",
     "dumi": "^2.1.2",
-    "enzyme": "^3.1.1",
-    "enzyme-adapter-react-16": "^1.15.6",
-    "enzyme-to-json": "^3.1.2",
     "eslint": "^7.1.0",
     "father": "^4.0.0",
     "gh-pages": "^3.1.0",
     "less": "^3.0.0",
     "rc-test": "^7.0.15",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {

--- a/src/Rate.tsx
+++ b/src/Rate.tsx
@@ -1,6 +1,4 @@
-import useControlledState from '@rc-component/util/lib/hooks/useControlledState';
-import KeyCode from '@rc-component/util/lib/KeyCode';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { KeyCode, pickAttrs, useControlledState } from '@rc-component/util';
 import { clsx } from 'clsx';
 import React from 'react';
 import type { StarProps } from './Star';

--- a/src/Star.tsx
+++ b/src/Star.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import KeyCode from '@rc-component/util/lib/KeyCode';
+import { KeyCode } from '@rc-component/util';
 import { clsx } from 'clsx';
+import React from 'react';
 
 export interface StarProps {
   value?: number;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,3 @@
 import Rate from './Rate';
 
-export type { RateProps, RateRef } from './Rate';
-export type { StarProps } from './Star';
-
 export default Rate;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,6 @@
 import Rate from './Rate';
 
+export type { RateProps, RateRef } from './Rate';
+export type { StarProps } from './Star';
+
 export default Rate;

--- a/tests/props.spec.js
+++ b/tests/props.spec.js
@@ -8,9 +8,11 @@ describe('props', () => {
       <Rate characterRender={(_, { index }) => <span className="render-holder">{index}</span>} />,
     );
 
-    Array.from(container.querySelectorAll('li')).forEach((li, index) => {
-      expect(li.querySelectorAll('span.render-holder')).toHaveLength(1);
-      expect(li.textContent).toEqual(String(index));
+    const holders = container.querySelectorAll('span.render-holder');
+    expect(holders).toHaveLength(5);
+
+    holders.forEach((span, index) => {
+      expect(span.textContent).toEqual(String(index));
     });
   });
 });

--- a/tests/props.spec.js
+++ b/tests/props.spec.js
@@ -1,16 +1,16 @@
+import { render } from '@testing-library/react';
 import React from 'react';
-import { mount } from 'enzyme';
 import Rate from '../src';
 
 describe('props', () => {
   it('characterRender', () => {
-    const wrapper = mount(
+    const { container } = render(
       <Rate characterRender={(_, { index }) => <span className="render-holder">{index}</span>} />,
     );
 
-    wrapper.find('li').forEach((li, index) => {
-      expect(li.find('span.render-holder').length).toEqual(1);
-      expect(li.text()).toEqual(index);
+    Array.from(container.querySelectorAll('li')).forEach((li, index) => {
+      expect(li.querySelectorAll('span.render-holder')).toHaveLength(1);
+      expect(li.textContent).toEqual(String(index));
     });
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,1 @@
-global.requestAnimationFrame = cb => setTimeout(cb, 0);
-
-const Enzyme = require('enzyme');
-const Adapter = require('enzyme-adapter-react-16');
-
-Enzyme.configure({ adapter: new Adapter() });
+global.requestAnimationFrame = (cb) => setTimeout(cb, 0);

--- a/tests/simple.spec.js
+++ b/tests/simple.spec.js
@@ -1,27 +1,55 @@
+import { KeyCode } from '@rc-component/util';
+import { act, createEvent, fireEvent, render } from '@testing-library/react';
 import React from 'react';
-import { render, mount } from 'enzyme';
-import KeyCode from '@rc-component/util/lib/KeyCode';
 import Rate from '../src';
+
+const getRate = (container) => container.querySelector('.rc-rate');
+const getStars = (container) => Array.from(container.querySelectorAll('li'));
+const getStar = (container, index) => getStars(container)[index];
+const getStarHandler = (container, index) => container.querySelectorAll('li > div')[index];
+const mouseMoveWithPageX = (target, pageX) => {
+  const event = createEvent.mouseMove(target);
+  Object.defineProperty(event, 'pageX', {
+    configurable: true,
+    value: pageX,
+  });
+  fireEvent(target, event);
+};
+const mockStarRect = (container, index, width = 2) => {
+  const star = getStar(container, index);
+  Object.defineProperty(star, 'clientWidth', {
+    configurable: true,
+    value: width,
+  });
+  star.getBoundingClientRect = () => ({
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: width,
+    top: 0,
+    width,
+  });
+};
 
 describe('rate', () => {
   describe('full', () => {
     it('render works', () => {
-      const wrapper = render(<Rate count={3} value={1} className="custom" />);
-      expect(wrapper).toMatchSnapshot();
+      const { container } = render(<Rate count={3} value={1} className="custom" />);
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('render works in RTL', () => {
-      const wrapper = render(<Rate count={3} value={1} direction="rtl" className="custom" />);
-      expect(wrapper).toMatchSnapshot();
+      const { container } = render(<Rate count={3} value={1} direction="rtl" className="custom" />);
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('render works with character node', () => {
-      const wrapper = render(<Rate count={3} value={1} character="1" />);
-      expect(wrapper).toMatchSnapshot();
+      const { container } = render(<Rate count={3} value={1} character="1" />);
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('render works with character function', () => {
-      const wrapper = render(
+      const { container } = render(
         <Rate
           count={3}
           value={1}
@@ -30,68 +58,70 @@ describe('rate', () => {
           }}
         />,
       );
-      expect(wrapper).toMatchSnapshot();
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('click works', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1} onChange={handleChange} />);
-      wrapper.find('li > div').at(1).simulate('click');
+      const { container } = render(<Rate count={3} value={1} onChange={handleChange} />);
+      fireEvent.click(getStarHandler(container, 1));
       expect(handleChange).toBeCalledWith(2);
     });
 
     it('click works in RTL', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1} direction="rtl" onChange={handleChange} />);
-      wrapper.find('li > div').at(1).simulate('click');
+      const { container } = render(
+        <Rate count={3} value={1} direction="rtl" onChange={handleChange} />,
+      );
+      fireEvent.click(getStarHandler(container, 1));
       expect(handleChange).toBeCalledWith(2);
     });
 
     it('support mouseMove', () => {
-      const wrapper = mount(<Rate count={3} value={1} />);
-      wrapper.find('li > div').at(1).simulate('mouseMove');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-full')).toBe(true);
+      const { container } = render(<Rate count={3} value={1} />);
+      fireEvent.mouseMove(getStarHandler(container, 1));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-full')).toBe(true);
     });
 
     it('support mouseMove in RTL', () => {
-      const wrapper = mount(<Rate count={3} value={1} direction="rtl" />);
-      wrapper.find('li > div').at(1).simulate('mouseMove');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-full')).toBe(true);
+      const { container } = render(<Rate count={3} value={1} direction="rtl" />);
+      fireEvent.mouseMove(getStarHandler(container, 1));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-full')).toBe(true);
     });
 
     it('support focus and blur', () => {
-      const wrapper = mount(<Rate count={3} value={2} />);
-      wrapper.simulate('focus');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(true);
+      const { container } = render(<Rate count={3} value={2} />);
+      fireEvent.focus(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(true);
 
-      wrapper.simulate('blur');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(false);
+      fireEvent.blur(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(false);
     });
 
     it('support focus and blur in RTL', () => {
-      const wrapper = mount(<Rate count={3} value={2} direction="rtl" />);
-      wrapper.simulate('focus');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(true);
+      const { container } = render(<Rate count={3} value={2} direction="rtl" />);
+      fireEvent.focus(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(true);
 
-      wrapper.simulate('blur');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(false);
+      fireEvent.blur(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(false);
     });
 
     describe('support keyboard', () => {
       it('left & right', () => {
         const handleChange = jest.fn();
-        const wrapper = mount(<Rate count={3} value={1} onChange={handleChange} />);
-        wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
+        const { container } = render(<Rate count={3} value={1} onChange={handleChange} />);
+        fireEvent.keyDown(getRate(container), { keyCode: KeyCode.LEFT });
         expect(handleChange).toBeCalledWith(0);
         handleChange.mockReset();
-        wrapper.simulate('keyDown', { keyCode: KeyCode.RIGHT });
+        fireEvent.keyDown(getRate(container), { keyCode: KeyCode.RIGHT });
         expect(handleChange).toBeCalledWith(2);
       });
 
       it('enter', () => {
         const handleChange = jest.fn();
-        const wrapper = mount(<Rate count={3} value={1} onChange={handleChange} />);
-        wrapper.find('li > div').at(2).simulate('keyDown', { keyCode: KeyCode.ENTER });
+        const { container } = render(<Rate count={3} value={1} onChange={handleChange} />);
+        fireEvent.keyDown(getStarHandler(container, 2), { keyCode: KeyCode.ENTER });
         expect(handleChange).toBeCalledWith(3);
       });
     });
@@ -99,18 +129,22 @@ describe('rate', () => {
     describe('support keyboard in RTL', () => {
       it('left & right', () => {
         const handleChange = jest.fn();
-        const wrapper = mount(<Rate count={3} value={1} direction="rtl" onChange={handleChange} />);
-        wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
+        const { container } = render(
+          <Rate count={3} value={1} direction="rtl" onChange={handleChange} />,
+        );
+        fireEvent.keyDown(getRate(container), { keyCode: KeyCode.LEFT });
         expect(handleChange).toBeCalledWith(2);
         handleChange.mockReset();
-        wrapper.simulate('keyDown', { keyCode: KeyCode.RIGHT });
+        fireEvent.keyDown(getRate(container), { keyCode: KeyCode.RIGHT });
         expect(handleChange).toBeCalledWith(0);
       });
 
       it('enter', () => {
         const handleChange = jest.fn();
-        const wrapper = mount(<Rate count={3} value={1} direction="rtl" onChange={handleChange} />);
-        wrapper.find('li > div').at(2).simulate('keyDown', { keyCode: KeyCode.ENTER });
+        const { container } = render(
+          <Rate count={3} value={1} direction="rtl" onChange={handleChange} />,
+        );
+        fireEvent.keyDown(getStarHandler(container, 2), { keyCode: KeyCode.ENTER });
         expect(handleChange).toBeCalledWith(3);
       });
     });
@@ -118,85 +152,87 @@ describe('rate', () => {
 
   describe('allowHalf', () => {
     it('render works', () => {
-      const wrapper = render(<Rate count={3} value={1.5} allowHalf className="custom" />);
-      expect(wrapper).toMatchSnapshot();
+      const { container } = render(<Rate count={3} value={1.5} allowHalf className="custom" />);
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('render works more than half ', () => {
-      const wrapper = render(<Rate count={3} value={1.6} allowHalf className="custom" />);
-      expect(wrapper).toMatchSnapshot();
+      const { container } = render(<Rate count={3} value={1.6} allowHalf className="custom" />);
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('render works in RTL', () => {
-      const wrapper = render(
+      const { container } = render(
         <Rate count={3} value={1.5} allowHalf direction="rtl" className="custom" />,
       );
-      expect(wrapper).toMatchSnapshot();
+      expect(getRate(container)).toMatchSnapshot();
     });
 
     it('click works', () => {
-      const wrapper = mount(<Rate count={5} value={4.5} allowHalf />);
-      wrapper.find('li > div').at(2).simulate('click');
-      expect(wrapper.find('li').at(4).hasClass('rc-rate-star-full')).toBe(false);
+      const { container } = render(<Rate count={5} value={4.5} allowHalf />);
+      fireEvent.click(getStarHandler(container, 2));
+      expect(getStar(container, 4).classList.contains('rc-rate-star-full')).toBe(false);
     });
 
     it('support focus and blur', () => {
-      const wrapper = mount(<Rate count={3} value={1.5} allowHalf />);
-      wrapper.simulate('focus');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(true);
+      const { container } = render(<Rate count={3} value={1.5} allowHalf />);
+      fireEvent.focus(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(true);
 
-      wrapper.simulate('blur');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(false);
+      fireEvent.blur(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(false);
     });
 
     it('support focus and blur in RTL', () => {
-      const wrapper = mount(<Rate count={3} value={1.5} direction="rtl" allowHalf />);
-      wrapper.simulate('focus');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(true);
+      const { container } = render(<Rate count={3} value={1.5} direction="rtl" allowHalf />);
+      fireEvent.focus(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(true);
 
-      wrapper.simulate('blur');
-      expect(wrapper.find('li').at(1).hasClass('rc-rate-star-focused')).toBe(false);
+      fireEvent.blur(getRate(container));
+      expect(getStar(container, 1).classList.contains('rc-rate-star-focused')).toBe(false);
     });
 
     it('support keyboard', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1.5} allowHalf onChange={handleChange} />);
-      wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
+      const { container } = render(
+        <Rate count={3} value={1.5} allowHalf onChange={handleChange} />,
+      );
+      fireEvent.keyDown(getRate(container), { keyCode: KeyCode.LEFT });
       expect(handleChange).toBeCalledWith(1);
       handleChange.mockReset();
-      wrapper.simulate('keyDown', { keyCode: KeyCode.RIGHT });
+      fireEvent.keyDown(getRate(container), { keyCode: KeyCode.RIGHT });
       expect(handleChange).toBeCalledWith(2);
     });
 
     it('support keyboard in RTL', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <Rate count={3} value={1.5} allowHalf direction="rtl" onChange={handleChange} />,
       );
-      wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
+      fireEvent.keyDown(getRate(container), { keyCode: KeyCode.LEFT });
       expect(handleChange).toBeCalledWith(2);
       handleChange.mockReset();
-      wrapper.simulate('keyDown', { keyCode: KeyCode.RIGHT });
+      fireEvent.keyDown(getRate(container), { keyCode: KeyCode.RIGHT });
       expect(handleChange).toBeCalledWith(1);
     });
 
     it('hover Rate of allowHalf', () => {
       const onHoverChange = jest.fn();
-      const wrapper = mount(<Rate count={3} value={1} allowHalf onHoverChange={onHoverChange} />);
-      wrapper.find('li > div').at(1).simulate('mouseMove', {
-        pageX: -1,
-      });
+      const { container } = render(
+        <Rate count={3} value={1} allowHalf onHoverChange={onHoverChange} />,
+      );
+      mockStarRect(container, 1);
+      mouseMoveWithPageX(getStarHandler(container, 1), 0);
       expect(onHoverChange).toHaveBeenCalledWith(1.5);
     });
 
     it('hover Rate of allowHalf and rtl', () => {
       const onHoverChange = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <Rate count={3} value={1} allowHalf direction="rtl" onHoverChange={onHoverChange} />,
       );
-      wrapper.find('li > div').at(1).simulate('mouseMove', {
-        pageX: 1,
-      });
+      mockStarRect(container, 1);
+      mouseMoveWithPageX(getStarHandler(container, 1), 2);
       expect(onHoverChange).toHaveBeenCalledWith(1.5);
     });
   });
@@ -204,89 +240,79 @@ describe('rate', () => {
   describe('allowClear', () => {
     it('allowClear is false', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <Rate count={5} value={1} allowClear={false} onChange={handleChange} />,
       );
-      wrapper.find('li > div').at(3).simulate('click');
-      wrapper.find('li > div').at(3).simulate('click');
+      fireEvent.click(getStarHandler(container, 3));
+      fireEvent.click(getStarHandler(container, 3));
       expect(handleChange).toBeCalledWith(4);
     });
     it('allowClear is true', () => {
       const handleChange = jest.fn();
-      const wrapper = mount(<Rate count={5} value={4} onChange={handleChange} />);
-      wrapper.find('li > div').at(3).simulate('click');
+      const { container } = render(<Rate count={5} value={4} onChange={handleChange} />);
+      fireEvent.click(getStarHandler(container, 3));
       expect(handleChange).toBeCalledWith(0);
     });
     it('cleaned star disable hover', () => {
-      const wrapper = mount(<Rate count={5} defaultValue={4} />);
-      wrapper.find('li > div').at(3).simulate('click');
-      wrapper.find('li > div').at(3).simulate('mouseMove');
-      expect(wrapper.find('li').at(3).hasClass('rc-rate-star-full')).toBe(false);
+      const { container } = render(<Rate count={5} defaultValue={4} />);
+      fireEvent.click(getStarHandler(container, 3));
+      fireEvent.mouseMove(getStarHandler(container, 3));
+      expect(getStar(container, 3).classList.contains('rc-rate-star-full')).toBe(false);
     });
     it('cleaned star reset', () => {
-      const wrapper = mount(<Rate count={5} defaultValue={4} />);
-      wrapper.find('li > div').at(3).simulate('click');
-      wrapper.find('ul').simulate('mouseLeave');
-      wrapper.find('li > div').at(3).simulate('mouseMove');
-      expect(wrapper.find('li').at(3).hasClass('rc-rate-star-full')).toBe(true);
+      const { container } = render(<Rate count={5} defaultValue={4} />);
+      fireEvent.click(getStarHandler(container, 3));
+      fireEvent.mouseLeave(getRate(container));
+      fireEvent.mouseMove(getStarHandler(container, 3));
+      expect(getStar(container, 3).classList.contains('rc-rate-star-full')).toBe(true);
     });
   });
 
   describe('focus & blur', () => {
-    let container;
-    beforeEach(() => {
-      container = document.createElement('div');
-      document.body.appendChild(container);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(container);
-    });
-
     it('focus()', () => {
       const handleFocus = jest.fn();
       const rateRef = React.createRef();
-      mount(<Rate ref={rateRef} count={3} value={1} onFocus={handleFocus} />, {
-        attachTo: container,
+      render(<Rate ref={rateRef} count={3} value={1} onFocus={handleFocus} />);
+      act(() => {
+        rateRef.current.focus();
       });
-      rateRef.current.focus();
       expect(handleFocus).toBeCalled();
     });
 
     it('blur()', () => {
       const handleBlur = jest.fn();
       const rateRef = React.createRef();
-      mount(<Rate ref={rateRef} count={3} value={1} onBlur={handleBlur} />, {
-        attachTo: container,
+      render(<Rate ref={rateRef} count={3} value={1} onBlur={handleBlur} />);
+      act(() => {
+        rateRef.current.focus();
+        rateRef.current.blur();
       });
-      rateRef.current.focus();
-      rateRef.current.blur();
       expect(handleBlur).toBeCalled();
     });
 
     it('autoFocus', () => {
       const handleFocus = jest.fn();
-      mount(<Rate autoFocus count={3} value={1} onFocus={handleFocus} />, { attachTo: container });
+      render(<Rate autoFocus count={3} value={1} onFocus={handleFocus} />);
       expect(handleFocus).toBeCalled();
     });
   });
 
   describe('right class', () => {
     it('rtl', () => {
-      const wrapper = mount(<Rate count={3} value={1} direction="rtl" />);
-      expect(wrapper.find('.rc-rate-rtl').length).toBe(1);
+      const { container } = render(<Rate count={3} value={1} direction="rtl" />);
+      expect(getRate(container).classList.contains('rc-rate-rtl')).toBe(true);
     });
     it('disabled', () => {
-      const wrapper = mount(<Rate count={3} value={1} disabled />);
-      expect(wrapper.find('.rc-rate-disabled').length).toBe(1);
+      const { container } = render(<Rate count={3} value={1} disabled />);
+      expect(getRate(container).classList.contains('rc-rate-disabled')).toBe(true);
     });
   });
 
   describe('events', () => {
     it('onKeyDown', () => {
       const onKeyDown = jest.fn();
-      const wrapper = mount(<Rate count={3} onKeyDown={onKeyDown} />);
-      wrapper.simulate('keydown');
+      const { container } = render(<Rate count={3} onKeyDown={onKeyDown} />);
+      fireEvent.keyDown(getRate(container));
       expect(onKeyDown).toHaveBeenCalled();
     });
 
@@ -294,39 +320,34 @@ describe('rate', () => {
     it('range picker should accept onMouseEnter and onMouseLeave event when Rate component is diabled', () => {
       const handleMouseEnter = jest.fn();
       const handleMouseLeave = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <Rate onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} disabled />,
       );
-      wrapper.simulate('mouseenter');
+      fireEvent.mouseEnter(getRate(container));
       expect(handleMouseEnter).toHaveBeenCalled();
-      wrapper.simulate('mouseleave');
+      fireEvent.mouseLeave(getRate(container));
       expect(handleMouseLeave).toHaveBeenCalled();
     });
 
     it('range picker should accept onMouseEnter and onMouseLeave event when Rate component is not diabled', () => {
       const handleMouseEnter = jest.fn();
       const handleMouseLeave = jest.fn();
-      const wrapper = mount(
+      const { container } = render(
         <Rate onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} />,
       );
-      wrapper.simulate('mouseenter');
+      fireEvent.mouseEnter(getRate(container));
       expect(handleMouseEnter).toHaveBeenCalled();
-      wrapper.simulate('mouseleave');
+      fireEvent.mouseLeave(getRate(container));
       expect(handleMouseLeave).toHaveBeenCalled();
     });
 
     it('should ignore key presses when keyboard is false', () => {
       const mockChange = jest.fn();
       const mockKeyDown = jest.fn();
-      const wrapper = mount(
-        <Rate
-          defaultValue={3}
-          onChange={mockChange}
-          onKeyDown={mockKeyDown}
-          keyboard={false}
-        />
+      const { container } = render(
+        <Rate defaultValue={3} onChange={mockChange} onKeyDown={mockKeyDown} keyboard={false} />,
       );
-      wrapper.simulate('keyDown', { keyCode: KeyCode.LEFT });
+      fireEvent.keyDown(getRate(container), { keyCode: KeyCode.LEFT });
       expect(mockChange).not.toHaveBeenCalled();
       expect(mockKeyDown).toHaveBeenCalled();
     });
@@ -334,14 +355,14 @@ describe('rate', () => {
 
   describe('html attributes', () => {
     it('data-* and aria-* and role', () => {
-      const wrapper = mount(<Rate data-number="1" aria-label="label" role="button" />);
-      expect(wrapper.getDOMNode().getAttribute('data-number')).toBe('1');
-      expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('label');
-      expect(wrapper.getDOMNode().getAttribute('role')).toBe('button');
+      const { container } = render(<Rate data-number="1" aria-label="label" role="button" />);
+      expect(getRate(container).getAttribute('data-number')).toBe('1');
+      expect(getRate(container).getAttribute('aria-label')).toBe('label');
+      expect(getRate(container).getAttribute('role')).toBe('button');
     });
     it('id', () => {
-      const wrapper = mount(<Rate id="myrate" />);
-      expect(wrapper.getDOMNode().getAttribute('id')).toBe('myrate');
+      const { container } = render(<Rate id="myrate" />);
+      expect(getRate(container).getAttribute('id')).toBe('myrate');
     });
   });
 });


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到包含根入口导出的版本，并升级 `@rc-component/father-plugin`。
- 将 `@rc-component/util/lib/...` 深路径导入调整为从 `@rc-component/util` 根入口导入。
- 补充导出 `RateProps`、`RateRef` 和 `StarProps` 类型。
- 将测试从 Enzyme 迁移到 Testing Library，移除 `enzyme`、`enzyme-adapter-react-16`、`enzyme-to-json` 和相关 serializer/setup 配置。
- 测试环境 dev 依赖对齐到 React 18，运行时 `peerDependencies` 保持不变。

## 验证

- `npm test -- --runInBand` 通过。
- `npm run lint` 通过，保留既有 `react-hooks/exhaustive-deps` warning。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 升级 React 依赖至 18.0 版本
  * 升级关键依赖包至最新兼容版本
  * 迁移测试框架至 React Testing Library，移除 Enzyme 相关依赖
  * 优化测试配置与设置

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/rate/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->