### PR TITLE
fix: wrap generic event types in inline code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Then open `http://localhost:8000`.
 | `onChange` | (value: number) => void | - | Value change callback. |
 | `onFocus` | () => void | - | Focus callback. |
 | `onHoverChange` | (value: number) => void | - | Hover value callback. |
-| `onKeyDown` | React.KeyboardEventHandler<HTMLUListElement> | - | Keydown callback. |
-| `onMouseEnter` | React.MouseEventHandler<HTMLUListElement> | - | Mouse enter callback. |
-| `onMouseLeave` | React.MouseEventHandler<HTMLUListElement> | - | Mouse leave callback. |
+| `onKeyDown` | `React.KeyboardEventHandler<HTMLUListElement>` | - | Keydown callback. |
+| `onMouseEnter` | `React.MouseEventHandler<HTMLUListElement>` | - | Mouse enter callback. |
+| `onMouseLeave` | `React.MouseEventHandler<HTMLUListElement>` | - | Mouse leave callback. |
 
 ### Ref
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,9 +86,9 @@ npm start
 | `onChange` | (value: number) => void | - | 值变化回调。 |
 | `onFocus` | () => void | - | 聚焦回调。 |
 | `onHoverChange` | (value: number) => void | - | 悬浮值回调。 |
-| `onKeyDown` | React.KeyboardEventHandler<HTMLUListElement> | - | 按键回调。 |
-| `onMouseEnter` | React.MouseEventHandler<HTMLUListElement> | - | 鼠标进入回调。 |
-| `onMouseLeave` | React.MouseEventHandler<HTMLUListElement> | - | 鼠标离开回调。 |
+| `onKeyDown` | `React.KeyboardEventHandler<HTMLUListElement>` | - | 按键回调。 |
+| `onMouseEnter` | `React.MouseEventHandler<HTMLUListElement>` | - | 鼠标进入回调。 |
+| `onMouseLeave` | `React.MouseEventHandler<HTMLUListElement>` | - | 鼠标离开回调。 |
 
 ### Ref
 


### PR DESCRIPTION
`React.xxx<HTMLUListElement>` 中的 `<HTMLUListElement>` 被错误解析成了 JSX 组件，报错 Uncaught TypeError: Failed to construct 'HTMLUListElement' 导致页面白屏。
<img width="1218" height="234" alt="Snipaste_2026-07-18_10-28-50" src="https://github.com/user-attachments/assets/4e2752e3-6c24-455d-83f2-d38fc7162178" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 优化 `Rate` 组件事件回调类型的代码格式展示。
  * 同步更新中英文 README 中 `onKeyDown`、`onMouseEnter` 和 `onMouseLeave` 的类型说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->